### PR TITLE
added tested Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,53 @@
+# base image
+FROM ubuntu:14.04.5
+
+# install dependencies
+RUN apt-get -y update && apt-get install -y --no-install-recommends \
+    build-essential \
+    git \
+    apache2 \
+    php5 \
+    libapache2-mod-perl2 \
+    libapache2-mod-php5
+
+# clean up
+RUN apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm /var/log/dpkg.log
+
+# apache2 configuration
+RUN a2enmod include
+RUN a2enmod rewrite
+RUN a2enmod cgi
+RUN update-rc.d apache2 defaults
+
+# confd apache2 configuration
+RUN rm /etc/apache2/sites-enabled/000-default.conf
+ADD ubuntu.conf /etc/apache2/sites-enabled/000-default.conf
+
+# configure environment
+ENV LANG=C
+ENV APACHE_LOCK_DIR                     /var/lock/apache2
+ENV APACHE_RUN_DIR                      /var/run/apache2
+ENV APACHE_PID_FILE                     ${APACHE_RUN_DIR}/apache2.pid
+ENV APACHE_LOG_DIR                      /var/log/apache2
+ENV APACHE_RUN_USER                     www-data
+ENV APACHE_RUN_GROUP                    www-data
+ENV APACHE_MAX_REQUEST_WORKERS          32
+ENV APACHE_MAX_CONNECTIONS_PER_CHILD    1024
+ENV APACHE_ALLOW_OVERRIDE               None
+ENV APACHE_ALLOW_ENCODED_SLASHES        Off
+
+# deploy repo
+RUN cd /var/www/ \
+    && rm -rf html \
+    && git clone https://github.com/CSAILVision/LabelMeAnnotationTool.git html \
+    && cd html \
+    && make \
+    && chown -R ${APACHE_RUN_USER}:${APACHE_RUN_GROUP} /var/www
+
+# port binding
+EXPOSE 80
+
+# run
+CMD ["/usr/sbin/apache2ctl", "-D", "FOREGROUND"]

--- a/ubuntu.conf
+++ b/ubuntu.conf
@@ -1,0 +1,15 @@
+<VirtualHost *:80>
+    ServerAdmin webmaster@localhost
+    DocumentRoot /var/www/html
+    <Directory "/var/www/html">
+      Options Indexes FollowSymLinks MultiViews Includes ExecCGI
+      AddHandler cgi-script .cgi
+      AllowOverride all
+      Require all granted
+      AddType text/html .shtml
+      AddOutputFilter INCLUDES .shtml
+      DirectoryIndex index.shtml
+    </Directory>
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+</VirtualHost>


### PR DESCRIPTION
Thought this was missing a **Dockerfile** and #17 seemed to have some interest so decided to create one. Currently using this for some quick annotations.

**from docker hub**

``` bash
mkdir -p ~/Desktop/annotate/Images
mkdir -p ~/Desktop/annotate/Annotations
docker run -d --name annotate -p 1337:80 -v ~/Desktop/annotate/Images:/var/www/html/Images -v ~/Desktop/annotate/Annotations:/var/www/html/Annotations jungleai/annotate:latest
```

**from dockerfile**
You can also build your own image from this **Dockerfile** and do the following

``` bash
docker build -t yourorganisation/yourimagename:latest .
mkdir -p ~/Desktop/annotate/Images
mkdir -p ~/Desktop/annotate/Annotations
docker run -d --name annotate -p 1337:80 -v ~/Desktop/annotate/Images:/var/www/html/Images -v ~/Desktop/annotate/Annotations:/var/www/html/Annotations yourorganisation/yourimagename:latest
```

In either case use local folders as you like but running works with attaching host folders the container. In this way if you were to follow the example above and place a folder called `logos` in  `~/Desktop/annotate/Images` and you dump `.jpg` files in that folder. Then when running the container navigate to [http://localhost:1337/tool.html?mode=f&folder=logos](http://localhost:1337/tool.html?mode=f&folder=logos) to start annotating. You will find the xml's in `~/Desktop/annotate/Annotations/logos`.
