### PR TITLE
Change image regex from partial to exact match

### DIFF
--- a/annotationTools/perl/fetch_image.cgi
+++ b/annotationTools/perl/fetch_image.cgi
@@ -97,7 +97,7 @@ elsif($mode eq "f") {
 
 	# Get location of image in array:
 	for(my $j = 0; $j < scalar(@all_images); $j++) {
-	    if($all_images[$j] =~ m/$image/) {
+	    if($all_images[$j] =~ m/^$image$/) {
 		$i = $j;
 		last;
 	    }


### PR DESCRIPTION
I have a directory of images with filenames `0.jpg`, `1.jpg`, `2.jpg` … `10.jpg`, etc., and the regex would match `/0\.jpg/` with `10.jpg`. Because of this, it would only fetch a subset of the images in the directory (i.e., the images in the `$all_images` array between `0.jpg` and `10.jpg`), as this loop breaks when it matches with any filename that ends in `0.jpg` instead of exactly `0.jpg`.