### PR TITLE
fixed mode "c" bug

### DIFF
--- a/annotationTools/perl/fetch_image.cgi
+++ b/annotationTools/perl/fetch_image.cgi
@@ -1,4 +1,5 @@
 #!/usr/bin/perl
+require 'globalvariables.pl';
 
 use strict;
 use CGI;
@@ -67,24 +68,43 @@ if($mode eq "i") {
     close(FP);
 }
 elsif($mode eq "c") {
-    opendir(DIR,$LM_HOME . "Images/$collection") || die("Cannot read collections");
-    my @all_images = readdir(DIR);
-    closedir(DIR);
-
+    my $fname = $LM_HOME . "annotationCache/DirLists/$collection.txt";
+    
+    if(!open(FP,$fname)) {
+	print "Status: 404\n\n";
+	return;
+    }
+    
+    open(NUMLINES,"wc -l $fname |");
+    my $numlines = <NUMLINES>;
+    ($numlines,my $bar) = split(" DirLists",$numlines);
+    close(NUMLINES);
+    my @allimages_list=();# initialise empty array
+    my @alldir_list=();# initialise empty
+    $numlines =int($numlines)+1;
+    for(my $i=1; $i < $numlines; $i++) {
+	    my $fileinfo = readline(FP);
+        (my $temp_dir,my $temp_file) = split(",",$fileinfo);
+        $temp_file =~ tr/"\n"//d; # remove trailing newline
+        $allimages_list[$i-1]=$temp_file; #append images
+        $alldir_list[$i-1]=$temp_dir; 
+    } 
+    close(FP);
     my $c = 0;
-    foreach my $i (@all_images) {
-	if($i eq $image) {
+    foreach my $j (@allimages_list) {
+	if($j eq $image) {
 	    goto next_section;
 	}
 	$c = $c+1;
     }
   next_section:
-    if($c == scalar(@all_images)-1) {
+    if($c == scalar(@allimages_list)-1) {
 	$c = 1;
     }
-    $im_file = $all_images[$c+1];
-    $im_dir = $folder;
-}
+    $im_file = $allimages_list[$c+1];
+    $im_dir = $alldir_list[$c+1];
+}       
+
 elsif($mode eq "f") {
     opendir(DIR,$LM_HOME . "Images/$folder") || die("Cannot read folder $LM_HOME/Images/$folder");
     my @all_images = readdir(DIR);


### PR DESCRIPTION
the mode "c" from the documentation must basically read the foo.txt file created from populate_dirlist.sh and display them in order. The  pull request from #33 claims to correct it. But it doesn't read the foo.txt file at all. Thus I have updated fetch_image.cgi to read the foo.txt created from populate_dirlist.sh and display images in order. I have also added "require 'globalvariables.pl';" at the top of the script. 

Now mode "c" will work as documented

There is a small bug though.
while starting LabelMe for the first time. Manually give the first folder_name and image_name in the collections.txt in the url. After which clicking next will fetch images in order. 