### PR TITLE
ASSIGNMENT_ID_NOT_AVAILABLE on manage hit page should not return manu…

### DIFF
--- a/annotationTools/js/file_info.js
+++ b/annotationTools/js/file_info.js
@@ -218,6 +218,11 @@ function file_info() {
             }
             
             if(this.assignmentId=='ASSIGNMENT_ID_NOT_AVAILABLE') {
+                if (!document.referrer.includes("requestersandbox.mturk.com")
+                    && !document.referrer.includes("requester.mturk.com")){
+                    window.location = MThelpPage;
+                    return false;
+                }
                 window.location = MThelpPage;
                 return false;
             }


### PR DESCRIPTION
when assignment ID is set to ASSIGNMENT_ID_NOT_AVAILABLE **on manage hit page** it produces impossibility to **approve** submitted tasks, because instead of hits it loads **MThelpPage**. 

![alt text](https://i.imgur.com/mAv7w6k.png "manage hits manually")
![alt text](https://i.imgur.com/YTJvatp.png "manage hits manually")
but at the worker.mturk.com it works as expected:
![alt text](https://i.imgur.com/DaVj8AK.png "manage hits manually")
