### PR TITLE
Fix bug when use_parts is false.

### DIFF
--- a/annotationTools/js/object_list.js
+++ b/annotationTools/js/object_list.js
@@ -79,6 +79,8 @@ function RenderObjectList() {
 	  'ondrop="drop(event, '+ii+')" '+
 	  'ondragenter="return dragEnter(event)" '+
 	  'ondragover="return dragOver(event)">';
+      } else {
+      	html_str += '>';
       }
       
       // change the icon for parts


### PR DESCRIPTION
When use_parts is set to false and view_ObjList is true the script raises an exception and it cannot load the list of objects because of a closing '>' on a *div* tag.