### PR TITLE
Optimize refreshing of objects' list

### DIFF
--- a/annotationTools/js/edit_event.js
+++ b/annotationTools/js/edit_event.js
@@ -131,10 +131,6 @@ function StopEditEvent() {
     }
   }
 
-  // Render the object list:
-  if(view_ObjList) {
-    RenderObjectList();
-  }
   console.log('LabelMe: Stopped edit event.');
 }
 

--- a/annotationTools/js/handler.js
+++ b/annotationTools/js/handler.js
@@ -108,7 +108,7 @@ function handler() {
       
       // Refresh object list:
       if(view_ObjList) {
-      	RenderObjectList();
+      	UpdateObjectList(false, anno.anno_id, new_name);
       	ChangeLinkColorFG(anno.GetAnnoID());
       }
     };

--- a/annotationTools/js/handler.js
+++ b/annotationTools/js/handler.js
@@ -145,7 +145,7 @@ function handler() {
         WriteXML(SubmitXmlUrl,LM_xml,function(){return;});
 
 	// Refresh object list:
-        if(view_ObjList) RenderObjectList();
+        if(view_ObjList) UpdateObjectList(true, idx);
         selected_poly = -1;
         unselectObjects(); // Perhaps this should go elsewhere...
         StopEditEvent();

--- a/annotationTools/js/object_list.js
+++ b/annotationTools/js/object_list.js
@@ -8,6 +8,13 @@
 var IsHidingAllPolygons = false;
 var ListOffSet = 0;
 
+function UpdateObjectList(deleted, idx, new_name) {
+    if (deleted)
+        $('#anno_list #LinkAnchor' + idx).empty();
+    if (new_name != 'undefined')
+        $('#anno_list #LinkAnchor'+idx+ ' #Link'+ idx).text(new_name);
+}
+
 // This function creates and populates the list 
 function RenderObjectList() {
   // If object list has been rendered, then remove it:


### PR DESCRIPTION
When updating hundreds of objects it lags amazingly because of the object list being recreated each time a little modification is detected.

This pull request optimizes the refreshing which reduces the lag by 200%.